### PR TITLE
[Feat]: 登録ボタンの変更・登録、編集後にモーダルを追加

### DIFF
--- a/src/app/detail/[docId]/page.tsx
+++ b/src/app/detail/[docId]/page.tsx
@@ -123,8 +123,12 @@ const DetailPage = ({ params }: { params: { docId: string } }) => {
         </div>
       </div>
       <div className="flex justify-center mt-8 pt-8 w-full border-t">
-        <DeleteButton />
-        <LinkButton href={`/edit/${docId}/`} text="編集する" />
+        <div className="w-60">
+          <DeleteButton />
+        </div>
+        <div className="ml-4 w-60">
+          <LinkButton href={`/edit/${docId}/`} text="編集する" />
+        </div>
       </div>
     </>
   );

--- a/src/app/edit/[docId]/page.tsx
+++ b/src/app/edit/[docId]/page.tsx
@@ -3,11 +3,16 @@ import Image from 'next/image';
 import { useState, useEffect, ChangeEvent } from 'react';
 import { SubmitHandler, useForm, Controller } from 'react-hook-form';
 import { Input, InputItem } from '@/components/elements/input';
-import { Button, ButtonWithFileInput } from '@/components/elements/button';
+import {
+  Button,
+  LinkButton,
+  ButtonWithFileInput,
+} from '@/components/elements/button';
 import { DatePickerInput } from '@/components/elements/datePicker';
 import { Rating } from '@/components/parts/rating';
 import { Loading } from '@/components/parts/loading';
 import { RegionModal } from '@/components/parts/regionModal';
+import { Modal } from '@/components/parts/modal';
 import {
   getNote,
   uploadImage,
@@ -62,6 +67,7 @@ export default function EditPage({ params }: { params: { docId: string } }) {
     // todo: 型付け
     useState<any>(initialDataTemplate);
   const [imagePreview, setImagePreview] = useState<string>('');
+  const [doneSubmit, setDoneSubmit] = useState<boolean>(false);
   const { isOpen, openModal, closeModal } = useModal();
 
   const {
@@ -137,8 +143,10 @@ export default function EditPage({ params }: { params: { docId: string } }) {
       const imageUrl = await uploadImage(data.imageFiles[0]);
       await updateNote({ ...validateData, images: new Array(imageUrl) }, docId);
       await deleteImage(initialData.imageFiles[0]);
+      setDoneSubmit(true);
     } else {
       await updateNote({ ...validateData, images: [] }, docId);
+      setDoneSubmit(true);
     }
   };
 
@@ -445,6 +453,16 @@ export default function EditPage({ params }: { params: { docId: string } }) {
           resetValue={() => reset({ region: '' })}
           value={getValues('region')}
         />
+      )}
+      {doneSubmit && (
+        <Modal>
+          <div className="flex flex-col justify-center items-center">
+            <div className="text-lg font-bold">編集が完了しました</div>
+            <div className="mt-2 w-60">
+              <LinkButton href="/list/" text="一覧画面に戻る" />
+            </div>
+          </div>
+        </Modal>
       )}
     </>
   );

--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect, useCallback } from 'react';
 import { QueryDocumentSnapshot } from 'firebase/firestore';
-import { LinkButton } from '@/components/elements/button';
+import { FloatingButton } from '@/components/elements/button';
 import { ListItem } from '@/components/parts/listItem';
 import { Loading } from '@/components/parts/loading';
 import { useAuth } from '@/libs/hooks/useAuth';
@@ -68,15 +68,15 @@ const ListPage = () => {
 
   return (
     <>
-      <div className="flex justify-end">
-        <LinkButton href="/register" text="記録する" />
-      </div>
+      {isLoading && <Loading />}
       <ul className="mt-4 p-3 md:p-8 bg-white border-2 rounded">
         {listData.map((data, i) => (
           <ListItem data={data} index={i} key={`list-${i}`} />
         ))}
       </ul>
-      {isLoading && <Loading />}
+      <FloatingButton href="/register">
+        <span className="text-2xl sm:text-3xl text-slate-600">+</span>
+      </FloatingButton>
     </>
   );
 };

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,11 +3,16 @@ import Image from 'next/image';
 import { useState, ChangeEvent } from 'react';
 import { SubmitHandler, useForm, Controller } from 'react-hook-form';
 import { Input, InputItem } from '@/components/elements/input';
-import { Button, ButtonWithFileInput } from '@/components/elements/button';
+import {
+  Button,
+  LinkButton,
+  ButtonWithFileInput,
+} from '@/components/elements/button';
 import { DatePickerInput } from '@/components/elements/datePicker';
 import { Rating } from '@/components/parts/rating';
 import { Loading } from '@/components/parts/loading';
 import { RegionModal } from '@/components/parts/regionModal';
+import { Modal } from '@/components/parts/modal';
 import { addNote, uploadImage } from '@/libs/firebase/api/note';
 import { useAuth } from '@/libs/hooks/useAuth';
 import { useModal } from '@/libs/hooks/useModal';
@@ -35,6 +40,7 @@ type InitialInputType = {
 const Register = () => {
   const signInUser = useAuth();
   const [imagePreview, setImagePreview] = useState<string>('');
+  const [doneSubmit, setDoneSubmit] = useState<boolean>(false);
   const { isOpen, openModal, closeModal } = useModal();
 
   const {
@@ -89,8 +95,10 @@ const Register = () => {
     if (data.imageFiles.length > 0) {
       const imageUrl = await uploadImage(data.imageFiles[0]);
       await addNote({ ...validateData, images: new Array(imageUrl) });
+      setDoneSubmit(true);
     } else {
       await addNote({ ...validateData, images: [] });
+      setDoneSubmit(true);
     }
   };
 
@@ -391,6 +399,16 @@ const Register = () => {
           resetValue={() => reset({ region: '' })}
           value={getValues('region')}
         />
+      )}
+      {doneSubmit && (
+        <Modal>
+          <div className="flex flex-col justify-center items-center">
+            <div className="text-lg font-bold">登録が完了しました</div>
+            <div className="mt-2 w-60">
+              <LinkButton href="/list/" text="一覧画面に戻る" />
+            </div>
+          </div>
+        </Modal>
       )}
     </>
   );

--- a/src/components/elements/button.tsx
+++ b/src/components/elements/button.tsx
@@ -34,7 +34,7 @@ export const LinkButton: React.FC<LinkButtonProps> = (props) => {
   return (
     <Link
       href={href}
-      className={`flex justify-center items-center ml-4 max-w-60 w-full p-2 h-12 bg-white rounded-md border-solid border-2 ${
+      className={`flex justify-center items-center max-w-60 w-full p-2 h-12 bg-white rounded-md border-solid border-2 ${
         isBold ? 'font-bold' : 'font-nomal'
       }`}
     >

--- a/src/components/elements/button.tsx
+++ b/src/components/elements/button.tsx
@@ -43,6 +43,22 @@ export const LinkButton: React.FC<LinkButtonProps> = (props) => {
   );
 };
 
+type FloatingButtonProps = {
+  href: string;
+  children: React.ReactNode;
+};
+export const FloatingButton: React.FC<FloatingButtonProps> = (props) => {
+  const { href, children } = props;
+  return (
+    <Link
+      href={href}
+      className="fixed bottom-12 right-12 flex items-center justify-center w-12 h-12 sm:w-20 sm:h-20 border-solid border-2 sm:border-4 border-gray-600 rounded-full shadow-lg bg-gray-300"
+    >
+      {children}
+    </Link>
+  );
+};
+
 export const DeleteButton: React.FC = () => (
   <button
     type="button"

--- a/src/components/parts/modal.tsx
+++ b/src/components/parts/modal.tsx
@@ -1,7 +1,7 @@
 type ModalProps = {
-  modalTiele: string;
+  modalTiele?: string;
   onClose?: () => void;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export const Modal: React.FC<ModalProps> = (props) => {
@@ -13,18 +13,22 @@ export const Modal: React.FC<ModalProps> = (props) => {
         className="fixed overflow-y-auto overflow-x-hidden top-2/4 left-1/2 -translate-y-1/2 -translate-x-1/2 z-10 w-full h-full max-h-full bg-gray-600/70"
       />
       <div className="fixed top-2/4 left-1/2 -translate-y-1/2 -translate-x-1/2 z-20 p-4 lg:w-[calc(60%_-_1rem)] w-[calc(100%_-_1.5rem)] max-h-full shadow rounded-lg bg-white">
-        <div className="flex items-center justify-between pb-2 border-b rounded-t dark:border-gray-600">
-          <p className="text-lg font-semibold">{modalTiele}</p>
-          {onClose && (
-            <div
-              onClick={onClose}
-              className="relative w-8 h-8 
+        {(modalTiele || onClose) && (
+          <div className="flex items-center justify-between pb-2 rounded-t dark:border-gray-600">
+            {modalTiele && (
+              <p className="text-lg font-semibold">{modalTiele}</p>
+            )}
+            {onClose && (
+              <div
+                onClick={onClose}
+                className="relative w-8 h-8 
                        before:content-[''] before:absolute before:top-1/2 before:left-1/2 before:-translate-y-1/2 before:-translate-x-1/2 before:border-t-solid before:border-2 before:border-gray-500 before:w-6 before:rotate-45 
                        after:content-[''] after:absolute after:top-1/2 after:left-1/2 after:-translate-y-1/2 after:-translate-x-1/2 after:border-t-solid after:border-2 after:border-gray-500 after:w-6 after:-rotate-45"
-            />
-          )}
-        </div>
-        <div className="mt-2">{children}</div>
+              />
+            )}
+          </div>
+        )}
+        {children && <div className="mt-2">{children}</div>}
       </div>
     </>
   );


### PR DESCRIPTION
・登録ボタンをフローティングボタンに変更
・登録、編集後に一覧画面に遷移するようにモーダルを追加

### スクリーンショット
#### ・フローティングボタン
![buttonSP](https://github.com/user-attachments/assets/f28826ff-4102-4fbd-9df4-dd41d3b9f81f)
![buttonPC](https://github.com/user-attachments/assets/44d58deb-563d-48d1-a271-4a67d6f9bd98)

#### ・モーダル
![modalPC](https://github.com/user-attachments/assets/54ba5fc4-86c0-4b3f-b79a-d5a93062b2da)
![modalSP](https://github.com/user-attachments/assets/c6061278-bb41-4577-ac50-be00594f578b)

