### PR TITLE
[Fix]: データ未登録時の一覧画面の表示を修正

### DIFF
--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect, useCallback } from 'react';
 import { QueryDocumentSnapshot } from 'firebase/firestore';
-import { FloatingButton } from '@/components/elements/button';
+import { LinkButton, FloatingButton } from '@/components/elements/button';
 import { ListItem } from '@/components/parts/listItem';
 import { Loading } from '@/components/parts/loading';
 import { useAuth } from '@/libs/hooks/useAuth';
@@ -15,12 +15,11 @@ const ListPage = () => {
   const [lastVisible, setLastVisible] = useState<QueryDocumentSnapshot | null>(
     null
   );
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasMore, setHasMore] = useState<boolean>(true);
   const signInUser = useAuth();
 
   const getListData = async () => {
-    setIsLoading(true);
     const { data, lastVisible } = await getNoteList(signInUser.uid, LIST_LIMIT);
     setListData(data);
     setLastVisible(lastVisible);
@@ -66,18 +65,30 @@ const ListPage = () => {
     })();
   }, [signInUser.uid]);
 
-  return (
+  return !isLoading ? (
     <>
-      {isLoading && <Loading />}
-      <ul className="mt-4 p-3 md:p-8 bg-white border-2 rounded">
-        {listData.map((data, i) => (
-          <ListItem data={data} index={i} key={`list-${i}`} />
-        ))}
-      </ul>
-      <FloatingButton href="/register">
-        <span className="text-2xl sm:text-3xl text-slate-600">+</span>
-      </FloatingButton>
+      {listData.length > 0 ? (
+        <>
+          <ul className="mt-4 p-3 md:p-8 bg-white border-2 rounded">
+            {listData.map((data, i) => (
+              <ListItem data={data} index={i} key={`list-${i}`} />
+            ))}
+          </ul>
+          <FloatingButton href="/register">
+            <span className="text-2xl sm:text-3xl text-slate-600">+</span>
+          </FloatingButton>
+        </>
+      ) : (
+        <div className="flex flex-col justify-center items-center">
+          <div>登録されているデータがありません</div>
+          <div className="mt-2 w-60">
+            <LinkButton href="/register/" text="登録する" />
+          </div>
+        </div>
+      )}
     </>
+  ) : (
+    <Loading />
   );
 };
 

--- a/src/components/parts/loading.tsx
+++ b/src/components/parts/loading.tsx
@@ -1,10 +1,10 @@
 export const Loading: React.FC = () => {
   return (
-    <>
+    <div>
       <div className="fixed overflow-y-auto overflow-x-hidden top-2/4 left-1/2 -translate-y-1/2 -translate-x-1/2 z-10 w-full h-full max-h-full bg-gray-600/70" />
       <div className="fixed z-50 top-2/4 left-1/2 -translate-y-1/2 -translate-x-1/2">
         <div className="animate-spin h-20 w-20 border-4 border-blue-700 rounded-full border-t-transparent" />
       </div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
アカウント作成時、一覧画面に登録されたデータがないことを表示するように修正

### スクリーンショット
#### ・PC
![PC](https://github.com/user-attachments/assets/d3a3d21c-fade-4605-b7bd-233b2ee77b73)

#### ・SP
![sp](https://github.com/user-attachments/assets/7b2d838e-0fac-4e4a-be1e-ba51cf4cc281)

