### PR TITLE
[Fix]: 詳細画面の熟成年数の表示不具合を修正

### DIFF
--- a/src/app/detail/[docId]/page.tsx
+++ b/src/app/detail/[docId]/page.tsx
@@ -61,7 +61,7 @@ const DetailPage = ({ params }: { params: { docId: string } }) => {
         <div className="ml-4">
           <h1 className="font-bold text-lg">
             {noteData.distilleryName}
-            {noteData.aging && noteData.aging > 0 && `${noteData.aging}'年'`}
+            {noteData.aging && noteData.aging > 0 && `${noteData.aging}年`}
           </h1>
           <div className="mt-2">
             <Rating


### PR DESCRIPTION
詳細画面で熟成年数に''が表示される不具合を修正

#### 修正前
![修正前](https://github.com/user-attachments/assets/240c4a0c-9a7a-48bf-88e7-a75e1fd606f8)

#### 修正後
![修正後](https://github.com/user-attachments/assets/8397952d-4628-4952-910e-fc36eb9b14b8)
